### PR TITLE
Modifications bundle

### DIFF
--- a/Annotations/ImgResize.php
+++ b/Annotations/ImgResize.php
@@ -16,6 +16,8 @@ class ImgResize extends Annotation
     public $height;
 
     public $uploadDir;
+
+    public $uploadDirDate;
     
     public $strict;
     

--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ Create your doctrine entity, and put the annotation :
 - strict : (true or false, default is true) if strict is true, the thumbnail will have the strict height and width. If strict is false, then the height and width will be the maximum size of the saved thumbnail.
 - crop : (true or false, default is false) Would you like that the thumbnail could be cropped (interesting if strict is set to true)
 - uploadDir : the directory where to put the thumbnail (in the public directory)
-- uploadDirDate : (true or false, default is false) if the directory manages folders by date (uploadDir/YYYY/MM/)
+- uploadDirDate : (true or false, default is false) if the directory manages folders by date (uploadDir/YYYY/MM/). The folder must be existing.
 - saveField : the entity's field where to save the thumbnail's name

--- a/README.md
+++ b/README.md
@@ -30,4 +30,5 @@ Create your doctrine entity, and put the annotation :
 - strict : (true or false, default is true) if strict is true, the thumbnail will have the strict height and width. If strict is false, then the height and width will be the maximum size of the saved thumbnail.
 - crop : (true or false, default is false) Would you like that the thumbnail could be cropped (interesting if strict is set to true)
 - uploadDir : the directory where to put the thumbnail (in the public directory)
+- uploadDirDate : (true or false, default is false) if the directory manages folders by date (uploadDir/YYYY/MM/)
 - saveField : the entity's field where to save the thumbnail's name

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,7 +1,7 @@
 services:
     imgResize.post.persist:
        class: Weysan\DoctrineImgBundle\Listener\UploadDoctrineListener
-       arguments: [@service_container]
+       arguments: ["@service_container"]
        tags:
            - { name: doctrine.event_listener, event: preUpdate, connection: default }
            - { name: doctrine.event_listener, event: prePersist, connection: default }

--- a/Upload/Upload.php
+++ b/Upload/Upload.php
@@ -31,6 +31,9 @@ class Upload
     function __construct(ImgResize $annotations, UploadedFile $imageToUpload = null, $public_path = null ){
         
         $this->destinationDir = $annotations->uploadDir;
+		if($annotations->uploadDirDate) {
+            $this->destinationDir = $annotations->uploadDir . date('Y') . DIRECTORY_SEPARATOR . date('m') . DIRECTORY_SEPARATOR;
+        }
         
         $this->width = $annotations->width;
         $this->height = $annotations->height;


### PR DESCRIPTION
- services.yml : syntaxe symfony 3. (Arguments passé entre double quotes)
- Ajout d'un paramètre d'annotation pour permettre de gérer les miniatures dans des dossiers classés par date (uploadDIR/YYYY/MM/)